### PR TITLE
Fix use statements in example

### DIFF
--- a/book/src/advanced_features/dynamic_test_generation.md
+++ b/book/src/advanced_features/dynamic_test_generation.md
@@ -7,7 +7,8 @@ Test generators can be either sync or async (if the `tokio` feature is enabled).
 The following two examples demonstrate generating sync and async tests using the `#[test_gen]` attribute:
 
 ```rust
-use test_r::{add_test, DynamicTestRegistration, TestType, test_gen};
+use test_r::core::{DynamicTestRegistration, TestType};
+use test_r::{add_test, test_gen};
 
 struct Dep1 {
     value: i32,


### PR DESCRIPTION
I tried to follow the example and noticed a problem with the `use` statements.
By the way, I also failed to use `#[test_gen]` altogether. The generated test seems to be ignored when I run `cargo test`.