### PR TITLE
Fix IPC worker lifetime race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/example-tokio/src/lib.rs
+++ b/example-tokio/src/lib.rs
@@ -9,17 +9,24 @@ mod tests {
     use test_r::{never_report_time, tag, test};
     use tokio::io::AsyncWriteExt;
 
+    async fn write_captured_output(stdout: &[u8], stderr: &[u8]) {
+        let mut stdout_handle = tokio::io::stdout();
+        stdout_handle.write_all(stdout).await.unwrap();
+        stdout_handle.flush().await.unwrap();
+
+        let mut stderr_handle = tokio::io::stderr();
+        stderr_handle.write_all(stderr).await.unwrap();
+        stderr_handle.flush().await.unwrap();
+    }
+
     #[test]
     #[tag(output_capture_test)]
     async fn it_does_work() {
-        let _ = tokio::io::stdout()
-            .write(b"Print from 'it_does_work'\n")
-            .await
-            .unwrap();
-        let _ = tokio::io::stderr()
-            .write(b"Stderr from 'it_does_work'\n")
-            .await
-            .unwrap();
+        write_captured_output(
+            b"Print from 'it_does_work'\n",
+            b"Stderr from 'it_does_work'\n",
+        )
+        .await;
         let result = 2 + 2;
         assert_eq!(result, 5);
     }
@@ -27,14 +34,7 @@ mod tests {
     #[test]
     #[tag(output_capture_test)]
     async fn this_too() {
-        let _ = tokio::io::stdout()
-            .write(b"Print from 'this_too'\n")
-            .await
-            .unwrap();
-        let _ = tokio::io::stderr()
-            .write(b"Stderr from 'this_too'\n")
-            .await
-            .unwrap();
+        write_captured_output(b"Print from 'this_too'\n", b"Stderr from 'this_too'\n").await;
         let result = 2 + 2;
         assert_eq!(result, 4);
     }
@@ -43,14 +43,11 @@ mod tests {
     #[should_panic]
     #[tag(output_capture_test)]
     async fn panic_test_1() {
-        let _ = tokio::io::stdout()
-            .write(b"Print from 'panic_test_1'\n")
-            .await
-            .unwrap();
-        let _ = tokio::io::stderr()
-            .write(b"Stderr from 'panic_test_1'\n")
-            .await
-            .unwrap();
+        write_captured_output(
+            b"Print from 'panic_test_1'\n",
+            b"Stderr from 'panic_test_1'\n",
+        )
+        .await;
         panic!("This test should panic");
     }
 

--- a/test-r-core/Cargo.toml
+++ b/test-r-core/Cargo.toml
@@ -23,7 +23,7 @@ escape8259 = "0.5"
 futures = "0.3"
 interprocess = "2.4"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
-quick-xml = "0.38"
+quick-xml = "0.41"
 rand = "0.10"
 serde_json = "1.0.149"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "io-std"], optional = true }

--- a/test-r-core/src/execution/tests.rs
+++ b/test-r-core/src/execution/tests.rs
@@ -20,6 +20,109 @@ fn registered_test_in_module(name: &str, module_path: &str, deps: Vec<String>) -
     }
 }
 
+/// `remaining_count` counts tests that have not yet been reserved; it does
+/// not prove that a scheduler thread (or its IPC child) has finished. In
+/// particular, reserving the final test makes `is_done()` true while the
+/// owning parent can still send that test to its child.
+///
+/// This is deterministic coverage for the worker-lifetime race: an IPC child
+/// must remain alive in this state and wait for the parent's explicit
+/// `Shutdown` command rather than treating `is_done()` as a lifetime signal.
+#[test]
+fn reserving_final_test_does_not_end_ipc_worker_lifetime() {
+    let (mut execution, _filtered) = TestSuiteExecution::construct(
+        &Arguments::default(),
+        &[],
+        &[registered_test("final_test", Vec::new())],
+        &[],
+    );
+
+    let reserved = execution
+        .pick_next_sync()
+        .expect("the final test should be reserved");
+    assert!(
+        execution.is_done(),
+        "remaining_count reaches zero as soon as the final test is reserved"
+    );
+    assert!(
+        !crate::ipc::test_loop_should_exit(true, execution.is_done(), false),
+        "an IPC worker must await explicit parent shutdown while a reserved test can still be sent"
+    );
+
+    drop(reserved);
+}
+
+/// An IPC worker intentionally advances its private execution plan through
+/// the normal picker until it reaches the parent's commanded test. This keeps
+/// dependency materialization, sequential locks, and subtree cleanup exactly
+/// the same as in-process execution, but can exhaust that worker's plan before
+/// the shared parent plan is done. The owning parent thread must then retire,
+/// leaving another worker whose plan still contains the locked test to finish
+/// the suite.
+#[test]
+fn exhausted_worker_retires_without_stranding_locked_sequential_test() {
+    let ordinary = registered_test_in_module("ordinary", "ordinary", Vec::new());
+    let sequential_a = registered_test_in_module("sequential_a", "sequential", Vec::new());
+    let sequential_b = registered_test_in_module("sequential_b", "sequential", Vec::new());
+    let sequential_prop = RegisteredTestSuiteProperty::Sequential {
+        name: "sequential".to_string(),
+        crate_name: "tcrate".to_string(),
+        module_path: String::new(),
+    };
+    // Construction reverses this list before building the tree, so the
+    // sequential subtree is visited before the ordinary sibling.
+    let tests = [ordinary, sequential_b, sequential_a];
+
+    let (mut parent, _filtered) = TestSuiteExecution::construct(
+        &Arguments::default(),
+        &[],
+        &tests,
+        std::slice::from_ref(&sequential_prop),
+    );
+    let (mut worker, _filtered) =
+        TestSuiteExecution::construct(&Arguments::default(), &[], &tests, &[sequential_prop]);
+
+    let parent_sequential = parent
+        .pick_next_sync()
+        .expect("one parent worker should reserve the first sequential test");
+    assert_eq!(parent_sequential.test.module_path, "sequential");
+
+    let parent_ordinary = parent
+        .pick_next_sync()
+        .expect("another parent worker should bypass the locked subtree");
+    assert_eq!(parent_ordinary.test.module_path, "ordinary");
+
+    let worker_ordinary = loop {
+        let candidate = worker
+            .pick_next_sync()
+            .expect("ordinary test must remain in the worker plan");
+        if candidate.test.module_path == "ordinary" {
+            break candidate;
+        }
+        drop(candidate);
+    };
+    assert!(
+        worker.is_done(),
+        "locating the ordinary command consumes the worker's remaining private plan"
+    );
+    assert!(
+        crate::ipc::test_loop_should_exit(false, parent.is_done(), worker.is_done()),
+        "the parent thread owning this exhausted worker must retire even though the shared plan is not done"
+    );
+    assert!(!parent.is_done());
+
+    drop(worker_ordinary);
+    drop(parent_ordinary);
+    drop(parent_sequential);
+
+    let remaining = parent
+        .pick_next_sync()
+        .expect("the worker that held the sequential lock must be able to finish the subtree");
+    assert_eq!(remaining.test.module_path, "sequential");
+    drop(remaining);
+    assert!(parent.is_done());
+}
+
 /// A Cloneable dep whose constructor increments a counter (so we can
 /// assert it ran exactly once), encodes via simple little-endian bytes.
 fn registered_cloneable_dep(name: &str, counter: Arc<AtomicUsize>) -> RegisteredDependency {

--- a/test-r-core/src/ipc.rs
+++ b/test-r-core/src/ipc.rs
@@ -94,6 +94,28 @@ pub enum IpcCommand {
         request_id: u64,
         body: HostedRpcReplyBody,
     },
+    /// Tells an IPC worker that its owning parent scheduler thread will not
+    /// send any more commands. Worker lifetime is parent-controlled rather
+    /// than inferred from the worker's private execution plan, whose
+    /// `remaining_count` can reach zero before the parent is done dispatching.
+    Shutdown,
+}
+
+/// Returns whether a test loop should stop based on its execution plan.
+///
+/// An in-process runner owns its scheduler and stops when that scheduler is
+/// done. An IPC worker must ignore its private scheduler's completion state:
+/// only an explicit [`IpcCommand::Shutdown`] from its owning parent proves
+/// that no future [`IpcCommand::RunTest`] will arrive. Conversely, a parent
+/// scheduler thread must retire when its owned worker reports that its private
+/// plan is exhausted, even if the shared parent plan still has tests for other
+/// workers.
+pub(crate) fn test_loop_should_exit(
+    is_ipc_worker: bool,
+    execution_done: bool,
+    owned_worker_exhausted: bool,
+) -> bool {
+    owned_worker_exhausted || (!is_ipc_worker && execution_done)
 }
 
 /// Body of a [`IpcCommand::HostedRpcReply`]. Either the serialized return
@@ -192,6 +214,11 @@ pub enum IpcResponse {
     TestFinished {
         result: SerializableTestResult,
         finish_marker: String,
+        /// Whether the worker's private execution plan was exhausted while
+        /// locating this test. The owning parent scheduler thread must retire
+        /// after this response because the worker cannot accept another
+        /// `RunTest`, but the worker process remains alive until `Shutdown`.
+        worker_exhausted: bool,
     },
     /// Acknowledges a [`IpcCommand::ProvideCloneable`]. Echoes back the
     /// fully-qualified `dep_id` the command carried.
@@ -270,6 +297,14 @@ mod tests {
         let mut cursor = Cursor::new(&buf);
         let err = read_frame(&mut cursor).expect_err("must fail on empty");
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn worker_lifetime_and_parent_scheduler_capacity_are_distinct() {
+        assert!(test_loop_should_exit(false, true, false));
+        assert!(!test_loop_should_exit(true, true, false));
+        assert!(!test_loop_should_exit(true, false, false));
+        assert!(test_loop_should_exit(false, false, true));
     }
 
     #[cfg(feature = "tokio")]

--- a/test-r-core/src/sync.rs
+++ b/test-r-core/src/sync.rs
@@ -257,6 +257,13 @@ pub fn test_runner() -> ExitCode {
                 results.extend(thread_results);
                 host_windows.extend(thread_windows);
             }
+            if is_top_level_parent {
+                assert_eq!(
+                    results.len(),
+                    count,
+                    "IPC worker exhaustion stranded tests in the parent execution plan"
+                );
+            }
 
             drop(execution);
 
@@ -289,7 +296,11 @@ pub fn test_runner() -> ExitCode {
             output.finished_suite(&all_tests, &results, start.elapsed());
             exit_code = SuiteResult::exit_code(&results);
 
-            if exit_code == ExitCode::SUCCESS {
+            // IPC workers execute exactly one parent-controlled dispatch
+            // session. Suite-level retries belong to the top-level parent;
+            // after Shutdown this subprocess must exit instead of reconnecting
+            // to the same listener for an independent retry attempt.
+            if !is_top_level_parent || exit_code == ExitCode::SUCCESS {
                 break;
             } else {
                 remaining_retries -= 1;
@@ -370,8 +381,18 @@ fn test_thread(
     // can map host-log records onto the right test(s).
     let mut host_windows: Vec<crate::host_capture::HostWindow> = Vec::with_capacity(count);
     let mut expected_test = None;
+    let mut owned_worker_exhausted = false;
 
-    while !is_done(&execution) {
+    'test_loop: loop {
+        let is_ipc_worker = connection_arc.is_some();
+        if crate::ipc::test_loop_should_exit(
+            is_ipc_worker,
+            is_done(&execution),
+            owned_worker_exhausted,
+        ) {
+            break;
+        }
+
         if let Some(connection) = connection_arc.as_ref() {
             while expected_test.is_none() {
                 let command_bytes = {
@@ -389,6 +410,7 @@ fn test_thread(
                     } => {
                         expected_test = Some((name, crate_name, module_path));
                     }
+                    IpcCommand::Shutdown => break 'test_loop,
                     IpcCommand::ProvideCloneable { dep_id, wire_bytes } => {
                         // Worker-side: look up the registered Cloneable dep by
                         // its fully-qualified id, reconstruct the value via
@@ -481,6 +503,10 @@ fn test_thread(
                         next.deps.clone(),
                     )
                 };
+                owned_worker_exhausted = worker
+                    .as_ref()
+                    .map(|worker| worker.exhausted)
+                    .unwrap_or(false);
 
                 output.finished_running_test(&next.test, next.index, count, &result);
                 let window_end = Instant::now();
@@ -501,6 +527,7 @@ fn test_thread(
                     let response = IpcResponse::TestFinished {
                         result: (&result).into(),
                         finish_marker,
+                        worker_exhausted: is_done(&execution),
                     };
 
                     let msg =
@@ -528,6 +555,11 @@ fn test_thread(
             }
         }
     }
+
+    if let Some(worker) = worker {
+        worker.shutdown();
+    }
+
     (results, host_windows)
 }
 
@@ -1008,12 +1040,13 @@ pub(crate) fn run_sync_test_function(
 struct Worker {
     listener: interprocess::local_socket::Listener,
     process: Child,
-    out_handle: JoinHandle<()>,
-    err_handle: JoinHandle<()>,
+    _out_handle: JoinHandle<()>,
+    _err_handle: JoinHandle<()>,
     out_lines: Arc<Mutex<VecDeque<CapturedOutput>>>,
     err_lines: Arc<Mutex<VecDeque<CapturedOutput>>>,
     capture_enabled: Arc<Mutex<bool>>,
     connection: Stream,
+    exhausted: bool,
     /// Parent-held HostedRpc owner cells keyed by fully-qualified dep id. Used
     /// to dispatch incoming `IpcResponse::HostedRpcCall` frames from the worker
     /// subprocess back to the right owner.
@@ -1104,10 +1137,12 @@ impl Worker {
         let IpcResponse::TestFinished {
             result,
             finish_marker,
+            worker_exhausted,
         } = response
         else {
             unreachable!("loop only breaks on TestFinished")
         };
+        self.exhausted = worker_exhausted;
 
         if test.props.capture_control.requires_capturing(!nocapture) {
             let out_lines: Vec<_> =
@@ -1118,6 +1153,20 @@ impl Worker {
         } else {
             result.into_test_result(Vec::new(), Vec::new())
         }
+    }
+
+    /// Ends this worker only after its owning scheduler thread has finished.
+    /// A worker cannot infer that fact from its private execution plan because
+    /// its test order may diverge from the shared parent scheduler.
+    fn shutdown(mut self) {
+        let msg = serialize_to_byte_vec(&IpcCommand::Shutdown)
+            .expect("Failed to encode IPC shutdown command");
+        let dump_on_ipc_failure = self.dump_on_failure();
+        dump_on_ipc_failure.run(write_frame(&mut self.connection, &msg));
+
+        self.process
+            .wait()
+            .expect("Failed to wait for worker process");
     }
 
     /// Sends a Cloneable wire payload to this worker process and waits for
@@ -1386,12 +1435,13 @@ fn spawn_worker_if_needed(args: &Arguments) -> Option<Worker> {
         Some(Worker {
             listener,
             process,
-            out_handle,
-            err_handle,
+            _out_handle: out_handle,
+            _err_handle: err_handle,
             out_lines,
             err_lines,
             capture_enabled,
             connection,
+            exhausted: false,
             hosted_rpc_owner_cells: Arc::new(HashMap::new()),
         })
     } else {

--- a/test-r-core/src/tokio.rs
+++ b/test-r-core/src/tokio.rs
@@ -291,6 +291,13 @@ async fn async_test_runner() -> ExitCode {
             drop(execution);
 
             let mut results = results.lock().await;
+            if is_top_level_parent {
+                assert_eq!(
+                    results.len(),
+                    count,
+                    "IPC worker exhaustion stranded tests in the parent execution plan"
+                );
+            }
             // Drop parent-owned hosted / hosted-rpc owners BEFORE
             // finalising host capture so any `Drop` impls that
             // shutdown background threads / subprocesses get a chance
@@ -320,7 +327,11 @@ async fn async_test_runner() -> ExitCode {
             output.finished_suite(&all_tests, &results, start.elapsed());
             exit_code = SuiteResult::exit_code(&results);
 
-            if exit_code == ExitCode::SUCCESS {
+            // IPC workers execute exactly one parent-controlled dispatch
+            // session. Suite-level retries belong to the top-level parent;
+            // after Shutdown this subprocess must exit instead of reconnecting
+            // to the same listener for an independent retry attempt.
+            if !is_top_level_parent || exit_code == ExitCode::SUCCESS {
                 break;
             } else {
                 remaining_retries -= 1;
@@ -393,8 +404,18 @@ async fn test_thread(
     }
 
     let mut expected_test = None;
+    let mut owned_worker_exhausted = false;
 
-    while !is_done(&execution).await {
+    'test_loop: loop {
+        let is_ipc_worker = connection_arc.is_some();
+        if crate::ipc::test_loop_should_exit(
+            is_ipc_worker,
+            is_done(&execution).await,
+            owned_worker_exhausted,
+        ) {
+            break;
+        }
+
         if let Some(connection) = connection_arc.as_ref() {
             while expected_test.is_none() {
                 let mut conn = connection.lock().await;
@@ -413,6 +434,7 @@ async fn test_thread(
                     } => {
                         expected_test = Some((name, crate_name, module_path));
                     }
+                    IpcCommand::Shutdown => break 'test_loop,
                     IpcCommand::ProvideCloneable { dep_id, wire_bytes } => {
                         // Worker-side reconstruction (see sync.rs::apply_provided_wire_bytes).
                         apply_provided_wire_bytes(
@@ -505,26 +527,34 @@ async fn test_thread(
                     &mut worker,
                 )
                 .await;
+                owned_worker_exhausted = worker
+                    .as_ref()
+                    .map(|worker| worker.exhausted)
+                    .unwrap_or(false);
                 output.finished_running_test(&next.test, next.index, count, &result);
                 let window_end = std::time::Instant::now();
 
                 if let Some(connection) = connection_arc.as_ref() {
                     let finish_marker = Uuid::new_v4().to_string();
                     let finish_marker_line = format!("{finish_marker}\n");
-                    tokio::io::stdout()
+                    let mut stdout = tokio::io::stdout();
+                    stdout
                         .write_all(finish_marker_line.as_bytes())
                         .await
                         .unwrap();
-                    tokio::io::stderr()
+                    stdout.flush().await.unwrap();
+
+                    let mut stderr = tokio::io::stderr();
+                    stderr
                         .write_all(finish_marker_line.as_bytes())
                         .await
                         .unwrap();
-                    tokio::io::stdout().flush().await.unwrap();
-                    tokio::io::stderr().flush().await.unwrap();
+                    stderr.flush().await.unwrap();
 
                     let response = IpcResponse::TestFinished {
                         result: (&result).into(),
                         finish_marker,
+                        worker_exhausted: is_done(&execution).await,
                     };
                     let msg =
                         serialize_to_byte_vec(&response).expect("Failed to encode IPC response");
@@ -552,6 +582,10 @@ async fn test_thread(
                 windows_guard.push(window);
             }
         }
+    }
+
+    if let Some(worker) = worker {
+        worker.shutdown().await;
     }
 }
 
@@ -915,13 +949,14 @@ async fn run_test(
 
 struct Worker {
     _listener: Listener,
-    _process: Child,
+    process: Child,
     _out_handle: JoinHandle<()>,
     _err_handle: JoinHandle<()>,
     out_lines: Arc<Mutex<VecDeque<CapturedOutput>>>,
     err_lines: Arc<Mutex<VecDeque<CapturedOutput>>>,
     capture_enabled: Arc<Mutex<bool>>,
     connection: Stream,
+    exhausted: bool,
     /// Parent-held HostedRpc owner cells keyed by fully-qualified dep id. Used
     /// to dispatch incoming `IpcResponse::HostedRpcCall` frames from the worker
     /// subprocess back to the right owner.
@@ -1022,10 +1057,12 @@ impl Worker {
         let IpcResponse::TestFinished {
             result,
             finish_marker,
+            worker_exhausted,
         } = response
         else {
             unreachable!("loop only breaks on TestFinished")
         };
+        self.exhausted = worker_exhausted;
 
         if test.props.capture_control.requires_capturing(!nocapture) {
             let out_lines: Vec<_> =
@@ -1036,6 +1073,23 @@ impl Worker {
         } else {
             result.into_test_result(Vec::new(), Vec::new())
         }
+    }
+
+    /// Ends this worker only after its owning scheduler thread has finished.
+    /// A worker cannot infer that fact from its private execution plan because
+    /// its test order may diverge from the shared parent scheduler.
+    async fn shutdown(mut self) {
+        let msg = serialize_to_byte_vec(&IpcCommand::Shutdown)
+            .expect("Failed to encode IPC shutdown command");
+        let dump_on_ipc_failure = self.dump_on_failure();
+        dump_on_ipc_failure
+            .run(write_frame_async(&mut self.connection, &msg).await)
+            .await;
+
+        self.process
+            .wait()
+            .await
+            .expect("Failed to wait for worker process");
     }
 
     /// Async counterpart to `sync::Worker::provide_cloneable`. `dep_id` is the
@@ -1303,13 +1357,14 @@ async fn spawn_worker_if_needed(args: &Arguments) -> Option<Worker> {
 
         Some(Worker {
             _listener: listener,
-            _process: process,
+            process,
             _out_handle: out_handle,
             _err_handle: err_handle,
             out_lines,
             err_lines,
             connection,
             capture_enabled,
+            exhausted: false,
             hosted_rpc_owner_cells: Arc::new(HashMap::new()),
         })
     } else {


### PR DESCRIPTION
## Summary

- keep IPC workers alive until their owning parent scheduler thread explicitly sends `Shutdown`
- report worker-plan exhaustion to the parent so that scheduler thread retires without stranding tests assigned to other workers
- preserve the normal dependency materialization/destruction, sequential locking, and subtree cleanup path inside child processes
- add deterministic regression coverage for final-test reservation and locked sequential subtrees
- stabilize Tokio output-capture coverage by flushing the same stdout/stderr handles used for each write

## Root cause

`remaining_count` reaches zero when the final test is reserved, before that test has necessarily been dispatched to its child process. An idle child could therefore infer completion from its private execution plan and exit successfully while its parent was blocked on a sequential subtree. The parent could later send `RunTest` to that exited child and receive `UnexpectedEof`.

Workers now treat only the owning parent's explicit `Shutdown` command as the end of their lifetime. A `TestFinished` response reports whether that worker's private plan is exhausted, allowing the owning parent scheduler thread to retire safely while other threads finish the shared execution plan.

The output-capture flake was separate: each `tokio::io::stdout()` or `stderr()` call creates a distinct blocking writer. The fixture wrote through one temporary handle and effectively attempted to flush another, so the pending line could arrive after the finish marker. Both fixture output and Tokio finish markers now write and flush through the same handle.

## Compatibility

The private IPC wire shape changes, but workers are always spawned from the same executable as their parent. `Shutdown` is appended to preserve existing command discriminants. Suite retries remain owned by the top-level parent rather than being independently repeated by child processes.

## Verification

- `cargo test -p test-r-core --all-features` (98 passed)
- `cargo test -p test-r-core --no-default-features` (87 passed)
- `cargo test -p test-r --all-features`
- `cargo test -q -p test-r --all-features cargo_tests::async_output_capturing_works` repeated 50 times
- sync and Tokio nested-sequential focused examples at 8 test threads (6/6 each)
- `cargo clippy --no-deps --all-targets -- -Dwarnings`
- `cargo fmt --all -- --check`
- `git diff --check`
